### PR TITLE
fix: a single bulleted list is output as multiple lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ CL-USER> (common-doc.format:emit-to-string
 "# Hello World
 
 * First item
-
 * Second item
 
 

--- a/docs/index.lisp
+++ b/docs/index.lisp
@@ -88,7 +88,6 @@ CL-USER> (common-doc.format:emit-to-string
 "# Hello World
 
 * First item
-
 * Second item
 
 

--- a/src/emitter.lisp
+++ b/src/emitter.lisp
@@ -17,6 +17,7 @@
 
 
 (defvar *header-level*)
+(defvar *inhibit-paragraph-breaks* nil)
 
 (defvar *emit-section-anchors* t
   "When this variable is `T` (default), emitter outputs
@@ -200,7 +201,9 @@
                                             (node common-doc:paragraph)
                                             stream)
   (call-next-method)
-  (format stream "~2&"))
+  (if *inhibit-paragraph-breaks*
+      (format stream "~1&")
+      (format stream "~2&")))
 
 
 (defun get-line-backticks-count (line)
@@ -265,9 +268,10 @@
   
   (loop for item in (common-doc:children node)
         do (write-string "* " stream)
-           (common-doc.format:emit-document format item stream))
+           (let ((*inhibit-paragraph-breaks* t))
+             (common-doc.format:emit-document format item stream)))
 
-  (fresh-line stream))
+  (format stream "~%"))
 
 
 (defmethod common-doc.format:emit-document ((format markdown)
@@ -277,9 +281,10 @@
   (loop for item in (common-doc:children node)
         for idx upfrom 1
         do (format stream "~A. " idx)
-           (common-doc.format:emit-document format item stream))
+           (let ((*inhibit-paragraph-breaks* t))
+             (common-doc.format:emit-document format item stream)))
 
-  (fresh-line stream))
+  (format stream "~%"))
 
 ;;; Markup
 

--- a/t/core.lisp
+++ b/t/core.lisp
@@ -11,6 +11,8 @@
                 #:make-content
                 #:make-section
                 #:make-text
+                #:make-list-item
+                #:make-ordered-list
                 #:make-paragraph
                 #:text
                 #:title)
@@ -88,6 +90,34 @@ in the second.
 in first paragraph."))
                                  (make-paragraph (make-text "And some words
 in the second.")))))))
+
+
+(deftest test-bullet-parsing
+  (testing "Parsing a bullet list"
+    (compare (p "- test 1
+- test 2
+- test 3
+
+")
+             (make-unordered-list
+              (list
+               (make-list-item
+                (make-paragraph
+                 (make-text "test 1")))
+               (make-list-item
+                (make-paragraph
+                 (make-text "test 2")))
+               (make-list-item
+                (make-paragraph
+                 (make-text "test 3")))))))
+
+  (testing "Round tripping a bullet list"
+    (let ((md-string "* test 1
+* test 2
+* test 3
+
+"))
+      (ok (string-equal (mm (p md-string)) md-string)))))
 
 
 (deftest test-inline-code


### PR DESCRIPTION
Prevent paragraphs from converting a single bulleted list into multiple.

In Markdown any newline after a bullet declares the end of a bulleted list.  2 bulleted lists would be declared like this.

```
* item1

* item2
```

When experimenting I found that the following example would be parsed as one list but output as 2 bulleted lists.

```
CL-USER> (common-doc.format:emit-to-string
          (make-instance 'commondoc-markdown:markdown)
          (common-doc.format:parse-document
           (make-instance 'commondoc-markdown:markdown)
  "
\# Hello World

* First item
* Second item

"))
"# Hello World

* First item

* Second item

"
```