### PR TITLE
Fix to work with latest 3bmd

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -12,6 +12,8 @@
   (:import-from #:commondoc-markdown/raw-html
                 #:make-raw-html-block
                 #:make-raw-inline-html)
+  (:import-from #:commondoc-markdown/utils
+                #:parse-tree-to-text)
   (:export
    #:markdown
    #:make-markdown-link
@@ -179,12 +181,16 @@
               (let* ((label (getf content :label))
                      (label-nodes (make-inline-nodes label))
                      (definition (getf content :definition))
-                     (url (find-url definition)))
+                     ;; After https://github.com/3b/3bmd/issues/55 we might
+                     ;; get a list as link definition.
+                     (definition-as-a-text (parse-tree-to-text
+                                            (getf content :definition)))
+                     (url (find-url definition-as-a-text)))
                 (if url
                     (common-doc:make-web-link url
                                               label-nodes)
                     (make-markdown-link label-nodes
-                                        :definition definition))))
+                                        :definition definition-as-a-text))))
              (:explicit-link
               (let ((url (getf content :source))
                     (label (getf content :label)))

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -183,8 +183,7 @@
                      (definition (getf content :definition))
                      ;; After https://github.com/3b/3bmd/issues/55 we might
                      ;; get a list as link definition.
-                     (definition-as-a-text (parse-tree-to-text
-                                            (getf content :definition)))
+                     (definition-as-a-text (parse-tree-to-text definition))
                      (url (find-url definition-as-a-text)))
                 (if url
                     (common-doc:make-web-link url

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -1,0 +1,45 @@
+(uiop:define-package #:commondoc-markdown/utils
+  (:use #:cl)
+  (:import-from #:str
+                #:starts-with-p))
+(in-package #:commondoc-markdown/utils)
+
+
+(declaim (inline parse-tree-p))
+(defun parse-tree-p (parse-tree tag)
+  (and (listp parse-tree)
+       (eq (first parse-tree) tag)))
+
+
+(defun parse-tree-to-text (parse-tree &key deemph)
+  ;; This function was taken from:
+  ;; https://github.com/melisgl/mgl-pax/blob/f7a6c51b187b10dc39470b77fac05aaeb7b4e781/src/document/markdown.lisp#L170
+  (labels
+      ((recurse (e)
+         (cond ((stringp e)
+                ;; "S" -> "S"
+                e)
+               ((and (listp e)
+                     (or (stringp (first e))
+                         (listp (first e))))
+                ;; ("mgl-pax-test:" (:EMPH "test-variable")) =>
+                ;; "mgl-pax-test:*test-variable*"
+                (apply #'concatenate 'string (mapcar #'recurse e)))
+               ;; Recurse into (:PLAIN ...)
+               ((parse-tree-p e :plain)
+                (format nil "~A" (recurse (rest e))))
+               ;; (:EMPH "S") -> "*S*"
+               ((and deemph (parse-tree-p e :emph))
+                (format nil "*~A*" (recurse (rest e))))
+               ;; (:CODE "S") -> "S"
+               ((parse-tree-p e :code)
+                (let ((string (second e)))
+                  (cond ((starts-with-p "\\\\" string)
+                         (recurse (subseq string 2)))
+                        ((starts-with-p "\\" string)
+                         (recurse (subseq string 1)))
+                        (t
+                         (recurse string)))))
+               (t
+                (return-from parse-tree-to-text nil)))))
+    (recurse parse-tree)))


### PR DESCRIPTION
After the commit https://github.com/3b/3bmd/commit/9a957f9d341d9ac3d72b85e2783e0d17d25a29e7 added to solve issue https://github.com/3b/3bmd/issues/55, 3bmd started to return link definition as a list.

This fix transforms such a list back to the string.